### PR TITLE
Adds RTM branch support to version calculation

### DIFF
--- a/MinVer.Lib/Git.cs
+++ b/MinVer.Lib/Git.cs
@@ -38,6 +38,17 @@ internal static class Git
         return true;
     }
 
+    public static IEnumerable<(string Name, string Sha)> GetBranches(string directory, ILogger log) =>
+        GitCommand.TryRun("show-ref --heads --dereference", directory, log, out var output)
+            ? output
+                .Split(newLineChars, StringSplitOptions.RemoveEmptyEntries)
+                .Select(line => line.Split(" ", 2))
+                .Select(tokens => (tokens[1][11..].RemoveFromEnd("^{}"), tokens[0]))
+            : [];
+
+    public static string GetCurrentBranch(string directory, ILogger log)
+        => GitCommand.TryRun("rev-parse --abbrev-ref HEAD", directory, log, out var output) ? output.Trim() : string.Empty;
+
     public static IEnumerable<(string Name, string Sha)> GetTags(string directory, ILogger log) =>
         GitCommand.TryRun("show-ref --tags --dereference", directory, log, out var output)
             ? output

--- a/MinVer.Lib/Version.cs
+++ b/MinVer.Lib/Version.cs
@@ -44,6 +44,7 @@ public class Version : SemanticVersion
                 VersionPart.Major => new Version(this.Major + 1, 0, 0, [.. defaultPreReleaseIdentifiers], newHeight, ""),
                 VersionPart.Minor => new Version(this.Major, this.Minor + 1, 0, [.. defaultPreReleaseIdentifiers], newHeight, ""),
                 VersionPart.Patch => new Version(this.Major, this.Minor, this.Patch + 1, [.. defaultPreReleaseIdentifiers], newHeight, ""),
+                VersionPart.None => new Version(this.Major, this.Minor, this.Patch, [.. defaultPreReleaseIdentifiers], newHeight, ""),
                 _ => throw new ArgumentOutOfRangeException(nameof(autoIncrement)),
             }
             : new Version(this.Major, this.Minor, this.Patch, this.preReleaseIdentifiers, newHeight, newHeight == 0 ? this.Metadata : "");

--- a/MinVer.Lib/VersionPart.cs
+++ b/MinVer.Lib/VersionPart.cs
@@ -2,6 +2,7 @@ namespace MinVer.Lib;
 
 public enum VersionPart
 {
+    None = -1,
     Patch = 0,
     Minor = 1,
     Major = 2,

--- a/MinVerTests.Lib/AutoIncrement.cs
+++ b/MinVerTests.Lib/AutoIncrement.cs
@@ -22,7 +22,7 @@ public static class AutoIncrement
         await Commit(path);
 
         // act
-        var actualVersion = Versioner.GetVersion(path, "", MajorMinor.Default, "", autoIncrement, PreReleaseIdentifiers.Default, false, NullLogger.Instance);
+        var actualVersion = Versioner.GetVersion(path, "", MajorMinor.Default, "", autoIncrement, PreReleaseIdentifiers.Default, false, null, NullLogger.Instance);
 
         // assert
         Assert.Equal(expectedVersion, actualVersion.ToString());

--- a/MinVerTests.Lib/BuildMetadata.cs
+++ b/MinVerTests.Lib/BuildMetadata.cs
@@ -19,7 +19,7 @@ public static class BuildMetadata
         await EnsureEmptyRepository(path);
 
         // act
-        var actualVersion = Versioner.GetVersion(path, "", MajorMinor.Default, buildMetadata, default, PreReleaseIdentifiers.Default, false, NullLogger.Instance);
+        var actualVersion = Versioner.GetVersion(path, "", MajorMinor.Default, buildMetadata, default, PreReleaseIdentifiers.Default, false, null, NullLogger.Instance);
 
         // assert
         Assert.Equal(expectedVersion, actualVersion.ToString());
@@ -35,7 +35,7 @@ public static class BuildMetadata
         await EnsureEmptyRepositoryAndCommit(path);
 
         // act
-        var actualVersion = Versioner.GetVersion(path, "", MajorMinor.Default, buildMetadata, default, PreReleaseIdentifiers.Default, false, NullLogger.Instance);
+        var actualVersion = Versioner.GetVersion(path, "", MajorMinor.Default, buildMetadata, default, PreReleaseIdentifiers.Default, false, null, NullLogger.Instance);
 
         // assert
         Assert.Equal(expectedVersion, actualVersion.ToString());
@@ -56,7 +56,7 @@ public static class BuildMetadata
         await Tag(path, tag);
 
         // act
-        var actualVersion = Versioner.GetVersion(path, "", MajorMinor.Default, buildMetadata, default, PreReleaseIdentifiers.Default, false, NullLogger.Instance);
+        var actualVersion = Versioner.GetVersion(path, "", MajorMinor.Default, buildMetadata, default, PreReleaseIdentifiers.Default, false, null, NullLogger.Instance);
 
         // assert
         Assert.Equal(expectedVersion, actualVersion.ToString());
@@ -78,7 +78,7 @@ public static class BuildMetadata
         await Commit(path);
 
         // act
-        var actualVersion = Versioner.GetVersion(path, "", MajorMinor.Default, buildMetadata, default, PreReleaseIdentifiers.Default, false, NullLogger.Instance);
+        var actualVersion = Versioner.GetVersion(path, "", MajorMinor.Default, buildMetadata, default, PreReleaseIdentifiers.Default, false, null, NullLogger.Instance);
 
         // assert
         Assert.Equal(expectedVersion, actualVersion.ToString());

--- a/MinVerTests.Lib/DefaultPreReleaseIdentifiers.cs
+++ b/MinVerTests.Lib/DefaultPreReleaseIdentifiers.cs
@@ -22,7 +22,7 @@ public static class DefaultPreReleaseIdentifiers
 #pragma warning restore CA1062 // Validate arguments of public methods
 
         // act
-        var actualVersion = Versioner.GetVersion(path, "", MajorMinor.Default, "", default, identifierList, false, NullLogger.Instance);
+        var actualVersion = Versioner.GetVersion(path, "", MajorMinor.Default, "", default, identifierList, false, null, NullLogger.Instance);
 
         // assert
         Assert.Equal(expectedVersion, actualVersion.ToString());

--- a/MinVerTests.Lib/LogMessages.cs
+++ b/MinVerTests.Lib/LogMessages.cs
@@ -64,7 +64,7 @@ git merge bar baz --no-edit --no-ff --strategy=octopus
         var log = new TestLogger();
 
         // act
-        _ = Versioner.GetVersion(path, "", minMajorMinor, "", default, PreReleaseIdentifiers.Default, false, log);
+        _ = Versioner.GetVersion(path, "", minMajorMinor, "", default, PreReleaseIdentifiers.Default, false, null, log);
 
         // assert
         var logMessages = await ReplaceShas(log.ToString(), path);
@@ -103,7 +103,7 @@ git tag 1.0.0-foo.1
         var log = new TestLogger();
 
         // act
-        _ = Versioner.GetVersion(path, "", minMajorMinor, "", default, PreReleaseIdentifiers.Default, false, log);
+        _ = Versioner.GetVersion(path, "", minMajorMinor, "", default, PreReleaseIdentifiers.Default, false, null, log);
 
         // assert
         var logMessages = await ReplaceShas(log.ToString(), path);

--- a/MinVerTests.Lib/MinMajorMinor.cs
+++ b/MinVerTests.Lib/MinMajorMinor.cs
@@ -17,7 +17,7 @@ public static class MinMajorMinor
         await EnsureEmptyRepository(path);
 
         // act
-        var actualVersion = Versioner.GetVersion(path, "", new MajorMinor(1, 2), "", default, PreReleaseIdentifiers.Default, false, NullLogger.Instance);
+        var actualVersion = Versioner.GetVersion(path, "", new MajorMinor(1, 2), "", default, PreReleaseIdentifiers.Default, false, null, NullLogger.Instance);
 
         // assert
         Assert.Equal("1.2.0-alpha.0", actualVersion.ToString());
@@ -36,7 +36,7 @@ public static class MinMajorMinor
         var logger = new TestLogger();
 
         // act
-        var actualVersion = Versioner.GetVersion(path, "", new MajorMinor(major, minor), "", default, PreReleaseIdentifiers.Default, false, logger);
+        var actualVersion = Versioner.GetVersion(path, "", new MajorMinor(major, minor), "", default, PreReleaseIdentifiers.Default, false, null, logger);
 
         // assert
         Assert.Equal(expectedVersion, actualVersion.ToString());
@@ -52,7 +52,7 @@ public static class MinMajorMinor
         await EnsureEmptyRepositoryAndCommit(path);
 
         // act
-        var actualVersion = Versioner.GetVersion(path, "", new MajorMinor(1, 0), "", default, PreReleaseIdentifiers.Default, false, NullLogger.Instance);
+        var actualVersion = Versioner.GetVersion(path, "", new MajorMinor(1, 0), "", default, PreReleaseIdentifiers.Default, false, null, NullLogger.Instance);
 
         // assert
         Assert.Equal("1.0.0-alpha.0", actualVersion.ToString());

--- a/MinVerTests.Lib/TagPrefixes.cs
+++ b/MinVerTests.Lib/TagPrefixes.cs
@@ -21,7 +21,7 @@ public static class TagPrefixes
         await Tag(path, tag);
 
         // act
-        var actualVersion = Versioner.GetVersion(path, prefix, MajorMinor.Default, "", default, PreReleaseIdentifiers.Default, false, NullLogger.Instance);
+        var actualVersion = Versioner.GetVersion(path, prefix, MajorMinor.Default, "", default, PreReleaseIdentifiers.Default, false, null, NullLogger.Instance);
 
         // assert
         Assert.Equal(expectedVersion, actualVersion.ToString());

--- a/MinVerTests.Lib/Versions.cs
+++ b/MinVerTests.Lib/Versions.cs
@@ -81,7 +81,7 @@ git tag 1.1.0 -a -m '.'
         {
             await Checkout(path, sha);
 
-            var version = Versioner.GetVersion(path, "", MajorMinor.Default, "", default, PreReleaseIdentifiers.Default, false, log);
+            var version = Versioner.GetVersion(path, "", MajorMinor.Default, "", default, PreReleaseIdentifiers.Default, false, null, log);
             var versionString = version.ToString();
             var tagName = $"v/{versionString}";
 
@@ -110,7 +110,7 @@ git tag 1.1.0 -a -m '.'
         await EnsureEmptyRepository(path);
 
         // act
-        var version = Versioner.GetVersion(path, "", MajorMinor.Default, "", default, PreReleaseIdentifiers.Default, false, NullLogger.Instance);
+        var version = Versioner.GetVersion(path, "", MajorMinor.Default, "", default, PreReleaseIdentifiers.Default, false, null, NullLogger.Instance);
 
         // assert
         Assert.Equal("0.0.0-alpha.0", version.ToString());
@@ -124,7 +124,7 @@ git tag 1.1.0 -a -m '.'
         EnsureEmptyDirectory(path);
 
         // act
-        var version = Versioner.GetVersion(path, "", MajorMinor.Default, "", default, PreReleaseIdentifiers.Default, false, NullLogger.Instance);
+        var version = Versioner.GetVersion(path, "", MajorMinor.Default, "", default, PreReleaseIdentifiers.Default, false, null, NullLogger.Instance);
 
         // assert
         Assert.Equal("0.0.0-alpha.0", version.ToString());

--- a/minver-cli/Options.cs
+++ b/minver-cli/Options.cs
@@ -14,6 +14,7 @@ internal sealed class Options
         MajorMinor? minMajorMinor,
         string? tagPrefix,
         Verbosity? verbosity,
+        string? rtmBranch,
         Lib.Version? versionOverride)
     {
         this.AutoIncrement = autoIncrement;
@@ -24,6 +25,7 @@ internal sealed class Options
         this.MinMajorMinor = minMajorMinor;
         this.TagPrefix = tagPrefix;
         this.Verbosity = verbosity;
+        this.RtmBranch = rtmBranch;
         this.VersionOverride = versionOverride;
     }
 
@@ -54,6 +56,7 @@ internal sealed class Options
         }
 
         var buildMeta = GetEnvVar("MinVerBuildMetadata");
+        var rtmBranch = GetEnvVar("MinVerRtmBranch");
 
         var defaultPreReleaseIdentifiersEnvVar = GetEnvVar("MinVerDefaultPreReleaseIdentifiers");
         if (!string.IsNullOrEmpty(defaultPreReleaseIdentifiersEnvVar))
@@ -100,7 +103,7 @@ internal sealed class Options
             return false;
         }
 
-        options = new Options(autoIncrement, buildMeta, defaultPreReleaseIdentifiers, defaultPreReleasePhase, ignoreHeight, minMajorMinor, tagPrefix, verbosity, versionOverride);
+        options = new Options(autoIncrement, buildMeta, defaultPreReleaseIdentifiers, defaultPreReleasePhase, ignoreHeight, minMajorMinor, tagPrefix, verbosity, rtmBranch, versionOverride);
 
         return true;
     }
@@ -127,6 +130,7 @@ internal sealed class Options
         string? minMajorMinorOption,
         string? tagPrefixOption,
         string? verbosityOption,
+        string? rtmBranch,
 #if MINVER
         string? versionOverrideOption,
 #endif
@@ -178,7 +182,7 @@ internal sealed class Options
         }
 #endif
 
-        options = new Options(autoIncrement, buildMetaOption, defaultPreReleaseIdentifiers, defaultPreReleasePhaseOption, ignoreHeight, minMajorMinor, tagPrefixOption, verbosity, versionOverride);
+        options = new Options(autoIncrement, buildMetaOption, defaultPreReleaseIdentifiers, defaultPreReleasePhaseOption, ignoreHeight, minMajorMinor, tagPrefixOption, verbosity, rtmBranch, versionOverride);
 
         return true;
     }
@@ -193,6 +197,7 @@ internal sealed class Options
         this.MinMajorMinor ?? other.MinMajorMinor,
         this.TagPrefix ?? other.TagPrefix,
         this.Verbosity ?? other.Verbosity,
+        this.RtmBranch ?? other.RtmBranch,
         this.VersionOverride ?? other.VersionOverride);
 #endif
 
@@ -211,6 +216,8 @@ internal sealed class Options
     public string? TagPrefix { get; }
 
     public Verbosity? Verbosity { get; }
+
+    public string? RtmBranch { get; set; }
 
     public Lib.Version? VersionOverride { get; }
 }

--- a/minver-cli/Program.cs
+++ b/minver-cli/Program.cs
@@ -22,6 +22,7 @@ var ignoreHeightOption = app.Option<bool>("-i|--ignore-height", "Use the latest 
 var minMajorMinorOption = app.Option("-m|--minimum-major-minor <MINIMUM_MAJOR_MINOR>", MajorMinor.ValidValues, CommandOptionType.SingleValue);
 var tagPrefixOption = app.Option("-t|--tag-prefix <TAG_PREFIX>", "", CommandOptionType.SingleValue);
 var verbosityOption = app.Option("-v|--verbosity <VERBOSITY>", VerbosityMap.ValidValues, CommandOptionType.SingleValue);
+var rtmBranch = app.Option("-r|--rtm-branch <RTM_BRANCH>", "The branch to use for RTM", CommandOptionType.SingleValue);
 #if MINVER
 var versionOverrideOption = app.Option("-o|--version-override <VERSION>", "", CommandOptionType.SingleValue);
 #endif
@@ -45,6 +46,7 @@ app.OnExecute(() =>
         minMajorMinorOption.Value(),
         tagPrefixOption.Value(),
         verbosityOption.Value(),
+        rtmBranch.Value(),
 #if MINVER
         versionOverrideOption.Value(),
 #endif
@@ -86,7 +88,7 @@ app.OnExecute(() =>
     Version version;
     try
     {
-        version = Versioner.GetVersion(workDir, options.TagPrefix ?? "", options.MinMajorMinor ?? MajorMinor.Default, options.BuildMeta ?? "", options.AutoIncrement ?? default, defaultPreReleaseIdentifiers ?? PreReleaseIdentifiers.Default, options.IgnoreHeight ?? false, log);
+        version = Versioner.GetVersion(workDir, options.TagPrefix ?? "", options.MinMajorMinor ?? MajorMinor.Default, options.BuildMeta ?? "", options.AutoIncrement ?? default, defaultPreReleaseIdentifiers ?? PreReleaseIdentifiers.Default, options.IgnoreHeight ?? false, options.RtmBranch, log);
     }
     catch (NoGitException ex)
     {


### PR DESCRIPTION
✨ Introduces an option to specify an RTM branch for versioning
🔧 Extends CLI options and environment handling to accept RTM branch input
📝 Updates version calculation to detect the current branch and treat RTM branch differently—disables height-based auto increment when on RTM
📈 Enhances git utilities to retrieve current branch and branches list
🔍 Adjusts tests and internal API for RTM branch parameter compatibility

This enables precise control over release versioning by identifying a dedicated RTM branch and adjusting version increments accordingly.
